### PR TITLE
ignore lines that contain only whitespace

### DIFF
--- a/bin/prepare-data
+++ b/bin/prepare-data
@@ -156,6 +156,8 @@ def convert_citations(fs, matchfile, out):
         with open(f) as meta:
             meta.readline() # header
             for line in meta:
+                if not line.strip():
+                    continue  # Ignore lines that contain only whitespace.
                 fields = [s.replace('"', '""') for s in line.strip().split("\t")]
                 ll.append('"' + fields[0] + '","' + '","'.join(fields[2:9]) +
                         '"')


### PR DESCRIPTION
This dead simple edit modifies the `prepare-data` script to ignore lines that contain only whitespace. The script currently becomes confused when it sees a blank line (such as the one that unaccountably appears at the end of the `citations.tsv` files currently returned by JSTOR). After this change it will silently drop all blank lines it sees.

It will also drop well-formed lines that contain only empty cells. Such lines would consist only of tab characters. I believe that's a feature, not a bug, but I am not 100% certain.

If it seems a bit silly that I'm spending this much time describing a PR that adds two lines of code -- well -- it probably is.